### PR TITLE
Integrate OpenIddict token server

### DIFF
--- a/Backend/IdentityShield.API/IdentityShield.API.csproj
+++ b/Backend/IdentityShield.API/IdentityShield.API.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.0.0" />
+    <PackageReference Include="OpenIddict" Version="4.9.0" />
+    <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="4.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Backend/IdentityShield.API/Program.cs
+++ b/Backend/IdentityShield.API/Program.cs
@@ -1,6 +1,7 @@
 using Flaminco.MinimalMediatR.Extensions;
 using IdentityShield.Application;
 using IdentityShield.Infrastructure;
+using OpenIddict.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -46,7 +47,28 @@ builder.Services.AddSwaggerGen(config =>
 
 builder.Services.AddModules<Program>();
 
-builder.Services.AddApplicationDIContainer().AddInfrastructureDIContainer(builder.Configuration);
+builder.Services.AddApplicationDIContainer()
+       .AddInfrastructureDIContainer(builder.Configuration);
+
+builder.Services.AddOpenIddict()
+    .AddCore(options =>
+    {
+        options.UseEntityFrameworkCore()
+               .UseDbContext<ShieldDbContext>();
+    })
+    .AddServer(options =>
+    {
+        options.SetTokenEndpointUris("/connect/token");
+        options.AllowPasswordFlow();
+        options.AllowRefreshTokenFlow();
+        options.AcceptAnonymousClients();
+
+        options.UseAspNetCore()
+               .EnableTokenEndpointPassthrough();
+
+        options.AddDevelopmentEncryptionCertificate()
+               .AddDevelopmentSigningCertificate();
+    });
 
 builder.Services.AddAuthorization();
 

--- a/Backend/IdentityShield.Application/Providers/JwtTokenProvider.cs
+++ b/Backend/IdentityShield.Application/Providers/JwtTokenProvider.cs
@@ -6,6 +6,9 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
+using OpenIddict.Abstractions;
+using OpenIddict.Server;
+using OpenIddict.Server.AspNetCore;
 using System.Security.Claims;
 using System.Text;
 
@@ -13,7 +16,8 @@ namespace IdentityShield.Application.Providers
 {
     public sealed class JwtTokenProvider<TUser>(IOptions<ShieldOptions> shieldOptions,
                                                 IRefreshTokenRepository _refreshTokenRepo,
-                                                IIdentityClaimMapper<TUser> claimMapper) where TUser : IdentityUser
+                                                IIdentityClaimMapper<TUser> claimMapper,
+                                                IOpenIddictTokenGenerator _tokenGenerator) where TUser : IdentityUser
     {
         public async Task<JwtResponse> GetJwtAsync(TUser user, string[] roles, CancellationToken cancellationToken = default)
         {
@@ -22,11 +26,11 @@ namespace IdentityShield.Application.Providers
             return new JwtResponse
             {
                 RefreshToken = identityRefreshToken.Token,
-                AccessToken = GetAccessToken(shieldOptions, claimMapper, user, roles, identityRefreshToken.SessionId)
+                AccessToken = await GetAccessTokenAsync(shieldOptions, claimMapper, user, roles, identityRefreshToken.SessionId, cancellationToken)
             };
         }
 
-        private static string GetAccessToken(IOptions<ShieldOptions> shieldOptions, IIdentityClaimMapper<TUser> claimMapper, TUser user, string[] roles, Guid? sessionId)
+        private async Task<string> GetAccessTokenAsync(IOptions<ShieldOptions> shieldOptions, IIdentityClaimMapper<TUser> claimMapper, TUser user, string[] roles, Guid? sessionId, CancellationToken cancellationToken)
         {
             List<Claim> claims =
             [
@@ -50,18 +54,17 @@ namespace IdentityShield.Application.Providers
                 claims.Add(new Claim(shieldOptions.Value.SessionClaimType, sessionId.Value.ToString()));
             }
 
-            SecurityTokenDescriptor tokenDescriptor = new()
+            var identity = new ClaimsIdentity(claims, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme, shieldOptions.Value.NameClaimType, shieldOptions.Value.RoleClaimType);
+            var principal = new ClaimsPrincipal(identity);
+
+            principal.SetScopes([OpenIddictConstants.Scopes.OpenId, OpenIddictConstants.Scopes.OfflineAccess]);
+
+            foreach (var claim in principal.Claims)
             {
-                Subject = new ClaimsIdentity(claims),
-                Expires = DateTime.UtcNow.Add(shieldOptions.Value.AccessTokenExpiration),
-                SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(Encoding.UTF8.GetBytes(shieldOptions.Value.SecretKey)), SecurityAlgorithms.HmacSha256),
-                Issuer = shieldOptions.Value.Issuer,
-                IssuedAt = DateTime.UtcNow,
-            };
+                claim.SetDestinations(OpenIddictConstants.Destinations.AccessToken);
+            }
 
-            JsonWebTokenHandler jsonWebTokenHandler = new();
-
-            return jsonWebTokenHandler.CreateToken(tokenDescriptor);
+            return await _tokenGenerator.CreateAccessTokenAsync(principal, cancellationToken: cancellationToken);
         }
     }
 

--- a/Backend/IdentityShield.Infrastructure/ShieldDbContext.cs
+++ b/Backend/IdentityShield.Infrastructure/ShieldDbContext.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using OpenIddict.EntityFrameworkCore;
 using System.Text.Json;
 
 namespace IdentityShield.Infrastructure
@@ -17,6 +18,8 @@ namespace IdentityShield.Infrastructure
         protected override void OnModelCreating(ModelBuilder builder)
         {
             base.OnModelCreating(builder);
+
+            builder.UseOpenIddict();
 
             // Rename Identity tables
             builder.Entity<ShieldUser>(b => b.ToTable("ShieldUsers"));


### PR DESCRIPTION
## Summary
- add OpenIddict packages to API project
- configure OpenIddict server endpoints in Program.cs
- enable OpenIddict store mappings in `ShieldDbContext`
- update token provider to generate OIDC access tokens

## Testing
- `dotnet build IdentityShield.sln -c Release` *(fails: `dotnet` not found)*